### PR TITLE
Put knobs in safe area to prevent them from overflowing into the nodge

### DIFF
--- a/lib/src/knobs/knob_panel.dart
+++ b/lib/src/knobs/knob_panel.dart
@@ -9,11 +9,13 @@ class KnobPanel extends StatelessWidget {
   Widget build(BuildContext context) => Consumer<Knobs>(
         builder: (context, knobs, _) => knobs.all().isEmpty
             ? Container()
-            : Container(
-                color: Theme.of(context).canvasColor,
-                width: 200,
-                child: ListView(
-                  children: knobs.all().map((v) => v.build()).toList(),
+            : SafeArea(
+                child: Container(
+                  color: Theme.of(context).canvasColor,
+                  width: 200,
+                  child: ListView(
+                    children: knobs.all().map((v) => v.build()).toList(),
+                  ),
                 ),
               ),
       );


### PR DESCRIPTION
To prevent this from happening
<img width="696" alt="Screen Shot 2020-05-31 at 16 19 16" src="https://user-images.githubusercontent.com/360645/83347862-7bf10a80-a35a-11ea-8eb1-18fa254ae077.png">
