### PR TITLE
Added padding & background color parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ class MyApp extends StatelessWidget {
         children: [
           Story(
             name: 'Flat button',
+            padding: EdgeInsets.all(5), // optional padding customization
+            background: Colors.red, // optional background color customization
             builder: (_, k) => MaterialButton(
               onPressed: k.boolean('Enabled', initial: true) ? () {} : null,
               child: Text(k.text('Text', initial: 'Flat button')),

--- a/lib/src/story.dart
+++ b/lib/src/story.dart
@@ -13,7 +13,9 @@ class Story extends StatefulWidget {
     Key key,
     @required this.name,
     @required StoryBuilder builder,
-    this.section = ''
+    this.section = '',
+    this.background = Colors.white,
+    this.padding = const EdgeInsets.all(16)
   })  : _builder = builder,
         super(key: key);
 
@@ -21,8 +23,16 @@ class Story extends StatefulWidget {
     Key key,
     @required String name,
     @required Widget child,
-    String section = ''
-  }) : this(key: key, name: name, builder: (_, __) => child, section: section);
+    String section = '',
+    Color background = Colors.white,
+    EdgeInsets padding = const EdgeInsets.all(16)
+  }) : this(
+    key: key, 
+    name: name, 
+    background: background, 
+    padding: padding, 
+    builder: (_, __) => child, section: section,
+  );
 
   /// A unique name to identify this story.
   ///
@@ -36,6 +46,12 @@ class Story extends StatefulWidget {
 
   /// Widget to be displayed in the story. It will be centered on the page.
   final StoryBuilder _builder;
+
+  // the background color of the storyboard  
+  final Color background;
+  
+  // the padding of the storyboard
+  final EdgeInsets padding;
 
   String get path => ReCase(name).paramCase;
 
@@ -54,8 +70,9 @@ class _StoryState extends State<Story> {
         child: Row(
           children: [
             Expanded(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
+              child: Container(
+                color: widget.background,
+                padding: widget.padding,
                 child: Center(
                   child: Builder(
                     builder: (_) => Consumer<Knobs>(


### PR DESCRIPTION
There are occasions where the white background and default padding don't play well with the storybook components.

Here's an example of an input with a white background that wouldn't look good with the changes I made:

![Simulator Screen Shot - iPhone 11 - 2020-07-02 at 10 49 21](https://user-images.githubusercontent.com/1215868/86337663-b4358280-bc51-11ea-892a-afc5070af611.png)
