### PR TITLE
Add support for switching between light and dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+- Added a button to the app bar to switch between light and dark mode.
+- Removed the default value for the background color of a story.
+
 ## 0.1.4
 - Added Story::background property
 - Added Story::padding property

--- a/lib/src/knobs/knob_panel.dart
+++ b/lib/src/knobs/knob_panel.dart
@@ -10,7 +10,7 @@ class KnobPanel extends StatelessWidget {
         builder: (context, knobs, _) => knobs.all().isEmpty
             ? Container()
             : Container(
-                color: Theme.of(context).canvasColor,
+                color: Theme.of(context).cardColor,
                 width: 200,
                 child: ListView(
                   children: knobs.all().map((v) => v.build()).toList(),

--- a/lib/src/story.dart
+++ b/lib/src/story.dart
@@ -14,7 +14,7 @@ class Story extends StatefulWidget {
     @required this.name,
     @required StoryBuilder builder,
     this.section = '',
-    this.background = Colors.white,
+    this.background,
     this.padding = const EdgeInsets.all(16),
   })  : _builder = builder,
         super(key: key);
@@ -24,7 +24,7 @@ class Story extends StatefulWidget {
     @required String name,
     @required Widget child,
     String section = '',
-    Color background = Colors.white,
+    Color background,
     EdgeInsets padding = const EdgeInsets.all(16),
   }) : this(
           key: key,

--- a/lib/src/story_page_wrapper.dart
+++ b/lib/src/story_page_wrapper.dart
@@ -3,14 +3,13 @@ import 'package:provider/provider.dart';
 import 'package:storybook_flutter/src/breakpoint.dart';
 import 'package:storybook_flutter/src/iterables.dart';
 import 'package:storybook_flutter/src/story.dart';
+import 'package:storybook_flutter/src/theme_mode_provider.dart';
 
 class StoryPageWrapper extends StatelessWidget {
   const StoryPageWrapper({Key key, this.path}) : super(key: key);
 
   bool _shouldDisplayDrawer(BuildContext context) =>
       MediaQuery.of(context).breakpoint == Breakpoint.small;
-
-  final String path;
 
   @override
   Widget build(BuildContext context) {
@@ -26,25 +25,44 @@ class StoryPageWrapper extends StatelessWidget {
       children: stories,
     );
 
+    final themeModeProvider = Provider.of<ThemeModeProvider>(context);
+    const themeIcon = {
+      ThemeMode.system: Icon(Icons.brightness_auto),
+      ThemeMode.light: Icon(Icons.brightness_high),
+      ThemeMode.dark: Icon(Icons.brightness_3),
+    };
+
     return Scaffold(
       drawer: _shouldDisplayDrawer(context) ? Drawer(child: contents) : null,
-      appBar: AppBar(title: Text(story?.name ?? 'Storybook')),
+      appBar: AppBar(
+        title: Text(story?.name ?? 'Storybook'),
+        actions: [
+          IconButton(
+            icon: themeIcon[themeModeProvider.current],
+            onPressed: themeModeProvider.toggleThemeMode,
+          )
+        ],
+      ),
       body: _shouldDisplayDrawer(context)
           ? _buildStory(context, story)
           : Row(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
-                Container(width: 200, child: contents),
+                Container(
+                  width: 200,
+                  color: Theme.of(context).cardColor,
+                  child: contents,
+                ),
                 Expanded(child: _buildStory(context, story)),
               ],
             ),
     );
   }
 
-  Widget _buildStory(BuildContext context, Story story) => Container(
-        color: Colors.white,
-        child: Center(child: story ?? const Text('Select story')),
-      );
+  final String path;
+
+  Widget _buildStory(BuildContext context, Story story) =>
+      Center(child: story ?? const Text('Select story'));
 
   void _onStoryTap(BuildContext context, Story story) {
     if (_shouldDisplayDrawer(context)) Navigator.of(context).pop();

--- a/lib/src/story_page_wrapper.dart
+++ b/lib/src/story_page_wrapper.dart
@@ -3,10 +3,12 @@ import 'package:provider/provider.dart';
 import 'package:storybook_flutter/src/breakpoint.dart';
 import 'package:storybook_flutter/src/iterables.dart';
 import 'package:storybook_flutter/src/story.dart';
-import 'package:storybook_flutter/src/theme_mode_provider.dart';
+import 'package:storybook_flutter/src/theme_switcher.dart';
 
 class StoryPageWrapper extends StatelessWidget {
   const StoryPageWrapper({Key key, this.path}) : super(key: key);
+
+  final String path;
 
   bool _shouldDisplayDrawer(BuildContext context) =>
       MediaQuery.of(context).breakpoint == Breakpoint.small;
@@ -25,23 +27,11 @@ class StoryPageWrapper extends StatelessWidget {
       children: stories,
     );
 
-    final themeModeProvider = Provider.of<ThemeModeProvider>(context);
-    const themeIcon = {
-      ThemeMode.system: Icon(Icons.brightness_auto),
-      ThemeMode.light: Icon(Icons.brightness_high),
-      ThemeMode.dark: Icon(Icons.brightness_3),
-    };
-
     return Scaffold(
       drawer: _shouldDisplayDrawer(context) ? Drawer(child: contents) : null,
       appBar: AppBar(
         title: Text(story?.name ?? 'Storybook'),
-        actions: [
-          IconButton(
-            icon: themeIcon[themeModeProvider.current],
-            onPressed: themeModeProvider.toggleThemeMode,
-          )
-        ],
+        actions: [ThemeSwitcher()],
       ),
       body: _shouldDisplayDrawer(context)
           ? _buildStory(context, story)
@@ -58,8 +48,6 @@ class StoryPageWrapper extends StatelessWidget {
             ),
     );
   }
-
-  final String path;
 
   Widget _buildStory(BuildContext context, Story story) =>
       Center(child: story ?? const Text('Select story'));

--- a/lib/src/storybook.dart
+++ b/lib/src/storybook.dart
@@ -51,7 +51,7 @@ class Storybook extends StatelessWidget {
   /// Theme override for the dark theme.
   final ThemeData darkTheme;
 
-  /// The theme mode the indicates whether to use light or dark theme.
+  /// Indicates theme mode to use: light, dark or system.
   final ThemeMode themeMode;
 
   /// Stories in the storybook.
@@ -67,18 +67,18 @@ class Storybook extends StatelessWidget {
           ChangeNotifierProvider(create: (_) => ThemeModeProvider(themeMode))
         ],
         child: Builder(
-            builder: (context) => MaterialApp(
-                  themeMode: Provider.of<ThemeModeProvider>(context).current,
-                  theme: theme ?? ThemeData(brightness: Brightness.light),
-                  darkTheme:
-                      darkTheme ?? ThemeData(brightness: Brightness.dark),
-                  localizationsDelegates: localizationDelegates,
-                  onGenerateRoute: (settings) => StoryRoute(
-                    settings: settings,
-                    builder: (_) => StoryPageWrapper(
-                      path: settings.name.replaceFirst('/stories/', ''),
-                    ),
-                  ),
-                )),
+          builder: (context) => MaterialApp(
+            themeMode: Provider.of<ThemeModeProvider>(context).current,
+            theme: theme ?? ThemeData(brightness: Brightness.light),
+            darkTheme: darkTheme ?? ThemeData(brightness: Brightness.dark),
+            localizationsDelegates: localizationDelegates,
+            onGenerateRoute: (settings) => StoryRoute(
+              settings: settings,
+              builder: (_) => StoryPageWrapper(
+                path: settings.name.replaceFirst('/stories/', ''),
+              ),
+            ),
+          ),
+        ),
       );
 }

--- a/lib/src/storybook.dart
+++ b/lib/src/storybook.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:storybook_flutter/src/route.dart';
 import 'package:storybook_flutter/src/story.dart';
 import 'package:storybook_flutter/src/story_page_wrapper.dart';
+import 'package:storybook_flutter/src/theme_mode_provider.dart';
 
 /// A collection of stories.
 ///
@@ -39,11 +40,19 @@ class Storybook extends StatelessWidget {
     Key key,
     this.children = const [],
     this.theme,
+    this.darkTheme,
+    this.themeMode = ThemeMode.system,
     this.localizationDelegates,
   }) : super(key: key);
 
-  /// Theme override
+  /// Theme override for the light theme.
   final ThemeData theme;
+
+  /// Theme override for the dark theme.
+  final ThemeData darkTheme;
+
+  /// The theme mode the indicates whether to use light or dark theme.
+  final ThemeMode themeMode;
 
   /// Stories in the storybook.
   final List<Story> children;
@@ -52,17 +61,24 @@ class Storybook extends StatelessWidget {
   final List<LocalizationsDelegate> localizationDelegates;
 
   @override
-  Widget build(BuildContext context) => Provider.value(
-        value: children,
-        child: MaterialApp(
-          theme: theme ?? Theme.of(context),
-          localizationsDelegates: localizationDelegates,
-          onGenerateRoute: (settings) => StoryRoute(
-            settings: settings,
-            builder: (_) => StoryPageWrapper(
-              path: settings.name.replaceFirst('/stories/', ''),
-            ),
-          ),
-        ),
+  Widget build(BuildContext context) => MultiProvider(
+        providers: [
+          Provider.value(value: children),
+          ChangeNotifierProvider(create: (_) => ThemeModeProvider(themeMode))
+        ],
+        child: Builder(
+            builder: (context) => MaterialApp(
+                  themeMode: Provider.of<ThemeModeProvider>(context).current,
+                  theme: theme ?? ThemeData(brightness: Brightness.light),
+                  darkTheme:
+                      darkTheme ?? ThemeData(brightness: Brightness.dark),
+                  localizationsDelegates: localizationDelegates,
+                  onGenerateRoute: (settings) => StoryRoute(
+                    settings: settings,
+                    builder: (_) => StoryPageWrapper(
+                      path: settings.name.replaceFirst('/stories/', ''),
+                    ),
+                  ),
+                )),
       );
 }

--- a/lib/src/theme_mode_provider.dart
+++ b/lib/src/theme_mode_provider.dart
@@ -7,14 +7,8 @@ class ThemeModeProvider extends ChangeNotifier {
 
   ThemeMode get current => _current;
 
-  void toggleThemeMode() {
-    if (_current == ThemeMode.system) {
-      _current = ThemeMode.light;
-    } else if (_current == ThemeMode.light) {
-      _current = ThemeMode.dark;
-    } else {
-      _current = ThemeMode.system;
-    }
+  void toggle() {
+    _current = ThemeMode.values[(_current.index + 1) % ThemeMode.values.length];
     notifyListeners();
   }
 }

--- a/lib/src/theme_mode_provider.dart
+++ b/lib/src/theme_mode_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class ThemeModeProvider extends ChangeNotifier {
+  ThemeModeProvider(this._current);
+
+  ThemeMode _current;
+
+  ThemeMode get current => _current;
+
+  void toggleThemeMode() {
+    if (_current == ThemeMode.system) {
+      _current = ThemeMode.light;
+    } else if (_current == ThemeMode.light) {
+      _current = ThemeMode.dark;
+    } else {
+      _current = ThemeMode.system;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/src/theme_switcher.dart
+++ b/lib/src/theme_switcher.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:storybook_flutter/src/theme_mode_provider.dart';
+
+class ThemeSwitcher extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final themeModeProvider = Provider.of<ThemeModeProvider>(context);
+
+    return IconButton(
+      icon: themeModeProvider.current.icon,
+      onPressed: themeModeProvider.toggle,
+    );
+  }
+}
+
+extension on ThemeMode {
+  // ignore: missing_return
+  Icon get icon {
+    switch (this) {
+      case ThemeMode.system:
+        return const Icon(Icons.brightness_auto);
+      case ThemeMode.light:
+        return const Icon(Icons.brightness_high);
+      case ThemeMode.dark:
+        return const Icon(Icons.brightness_3);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: storybook_flutter
 description: A storybook for Flutter widgets. Live preview of isolated widgets for faster development and showcase.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/ookami-kb/storybook_flutter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.5
 homepage: https://github.com/ookami-kb/storybook_flutter
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   provider: ">=4.0.0 <5.0.0"


### PR DESCRIPTION
I often want to test whether my components look good in both light and dark mode. This adds a switcher in the app bar, toggling between auto, light and dark mode. This might resolve #14. I had to make some changes to the background colors of the drawer and the default color of a story, to make them look good in light and dark mode.