### PR TITLE
feat!: add story and knob description fields (@`next`)

### DIFF
--- a/packages/storybook_device_preview/example/lib/main.dart
+++ b/packages/storybook_device_preview/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:storybook_device_preview/storybook_device_preview.dart';
 
 void main() => runApp(const MyApp());

--- a/packages/storybook_flutter/CHANGELOG.md
+++ b/packages/storybook_flutter/CHANGELOG.md
@@ -1,96 +1,96 @@
 ## 0.9.0-dev.1
 
-- **FEAT**: Update plugins.
-- **FEAT**: Update plugins.
-- **DOCS**: Update example.
-- **CHORE**: Update pubignore.
+ - **FEAT**: Update plugins.
+ - **FEAT**: Update plugins.
+ - **DOCS**: Update example.
+ - **CHORE**: Update pubignore.
 
 ## 0.9.0-dev.0
 
 > Note: This release has breaking changes.
 
-- **CHORE**: Add .pubignore.
-- **CHORE**: Update .gitignore.
-- **BREAKING** **FEAT**: Reorganize (#59).
+ - **CHORE**: Add .pubignore.
+ - **CHORE**: Update .gitignore.
+ - **BREAKING** **FEAT**: Reorganize (#59).
 
 ## 0.8.0
 
 > Note: This release has breaking changes.
 
-- **TEST**: Update golden test images.
-- **FIX**: Remove deprecated accentColor.
-- **FEAT**: Add scaffoldMessengerKey to Storybook (#46).
-- **CHORE**: Update license (#49).
-- **BREAKING** **CHORE**: Update dependencies.
+ - **TEST**: Update golden test images.
+ - **FIX**: Remove deprecated accentColor.
+ - **FEAT**: Add scaffoldMessengerKey to Storybook (#46).
+ - **CHORE**: Update license (#49).
+ - **BREAKING** **CHORE**: Update dependencies.
 
 ## 0.7.0+1
 
-- **FIX**: Fix list views in macOS.
+ - **FIX**: Fix list views in macOS.
 
 ## 0.7.0
 
 > Note: This release has breaking changes.
 
-- **BREAKING** **FEAT**: Bump provider to 6.0.0 (#41).
+ - **BREAKING** **FEAT**: Bump provider to 6.0.0 (#41).
 
 ## 0.6.0
 
 > Note: This release has breaking changes.
 
-- **BREAKING** **FEAT**: Add sliderInt (#40).
+ - **BREAKING** **FEAT**: Add sliderInt (#40).
 
 ## 0.5.1
 
-- **FEAT**: Expose builder and navigatorObservers.
+ - **FEAT**: Expose builder and navigatorObservers.
 
 ## 0.5.0+1
 
-- **REFACTOR**: Remove dfunc dependency.
-- **REFACTOR**: Update dependencies.
+ - **REFACTOR**: Remove dfunc dependency.
+ - **REFACTOR**: Update dependencies.
 
 ## 0.5.0
 
-- Graduate package to a stable release. See pre-releases prior to this version for changelog entries.
+ - Graduate package to a stable release. See pre-releases prior to this version for changelog entries.
 
 ## 0.5.0-dev.1
 
-- **FIX**: Fix responsive layout.
-- **DOCS**: Update docs link.
-- **DOCS**: Update docs.
-- **DOCS**: Update demo.
-- **DOCS**: Add demo page.
+ - **FIX**: Fix responsive layout.
+ - **DOCS**: Update docs link.
+ - **DOCS**: Update docs.
+ - **DOCS**: Update demo.
+ - **DOCS**: Add demo page.
 
 ## 0.5.0-dev.0
 
 > Note: This release has breaking changes.
 
-- **BREAKING** **FEAT**: Add plugins.
+ - **BREAKING** **FEAT**: Add plugins.
 
 ## 0.4.1+2
 
-- **FIX**: Fix knobs reload for CustomStorybook.
+ - **FIX**: Fix knobs reload for CustomStorybook.
 
 ## 0.4.1+1
 
-- **STYLE**: Fix formatting.
-- **DOCS**: Update README.md.
+ - **STYLE**: Fix formatting.
+ - **DOCS**: Update README.md.
 
 ## 0.4.1
 
-- **FEAT**: Add storybook_device_preview.
-- **CHORE**: Update dependencies.
-- **CHORE**: Restructure.
+ - **FEAT**: Add storybook_device_preview.
+ - **CHORE**: Update dependencies.
+ - **CHORE**: Restructure.
 
 ## 0.4.0
 
-- Bump "storybook_flutter" to `0.4.0`.
+ - Bump "storybook_flutter" to `0.4.0`.
 
 ## 0.3.0
 
 > Note: This release has breaking changes.
 
-- **CI**: Add CI job (#20).
-- **BREAKING** **FEAT**: Major theme upgrade.
+ - **CI**: Add CI job (#20).
+ - **BREAKING** **FEAT**: Major theme upgrade.
 
 ## 0.2.1
 

--- a/packages/storybook_flutter/CHANGELOG.md
+++ b/packages/storybook_flutter/CHANGELOG.md
@@ -1,96 +1,105 @@
+## 0.9.0-dev.2
+
+> Note: This release has breaking changes.
+
+- **FEAT**: Add description field to stories and all knobs.
+- **CHORE**: Add docs to all knobs.
+- **FIX**: Fix bug where desktop users could not enter space in text knob fields.
+- **CHORE**: Version bump.
+
 ## 0.9.0-dev.1
 
- - **FEAT**: Update plugins.
- - **FEAT**: Update plugins.
- - **DOCS**: Update example.
- - **CHORE**: Update pubignore.
+- **FEAT**: Update plugins.
+- **FEAT**: Update plugins.
+- **DOCS**: Update example.
+- **CHORE**: Update pubignore.
 
 ## 0.9.0-dev.0
 
 > Note: This release has breaking changes.
 
- - **CHORE**: Add .pubignore.
- - **CHORE**: Update .gitignore.
- - **BREAKING** **FEAT**: Reorganize (#59).
+- **CHORE**: Add .pubignore.
+- **CHORE**: Update .gitignore.
+- **BREAKING** **FEAT**: Reorganize (#59).
 
 ## 0.8.0
 
 > Note: This release has breaking changes.
 
- - **TEST**: Update golden test images.
- - **FIX**: Remove deprecated accentColor.
- - **FEAT**: Add scaffoldMessengerKey to Storybook (#46).
- - **CHORE**: Update license (#49).
- - **BREAKING** **CHORE**: Update dependencies.
+- **TEST**: Update golden test images.
+- **FIX**: Remove deprecated accentColor.
+- **FEAT**: Add scaffoldMessengerKey to Storybook (#46).
+- **CHORE**: Update license (#49).
+- **BREAKING** **CHORE**: Update dependencies.
 
 ## 0.7.0+1
 
- - **FIX**: Fix list views in macOS.
+- **FIX**: Fix list views in macOS.
 
 ## 0.7.0
 
 > Note: This release has breaking changes.
 
- - **BREAKING** **FEAT**: Bump provider to 6.0.0 (#41).
+- **BREAKING** **FEAT**: Bump provider to 6.0.0 (#41).
 
 ## 0.6.0
 
 > Note: This release has breaking changes.
 
- - **BREAKING** **FEAT**: Add sliderInt (#40).
+- **BREAKING** **FEAT**: Add sliderInt (#40).
 
 ## 0.5.1
 
- - **FEAT**: Expose builder and navigatorObservers.
+- **FEAT**: Expose builder and navigatorObservers.
 
 ## 0.5.0+1
 
- - **REFACTOR**: Remove dfunc dependency.
- - **REFACTOR**: Update dependencies.
+- **REFACTOR**: Remove dfunc dependency.
+- **REFACTOR**: Update dependencies.
 
 ## 0.5.0
 
- - Graduate package to a stable release. See pre-releases prior to this version for changelog entries.
+- Graduate package to a stable release. See pre-releases prior to this version for changelog entries.
 
 ## 0.5.0-dev.1
 
- - **FIX**: Fix responsive layout.
- - **DOCS**: Update docs link.
- - **DOCS**: Update docs.
- - **DOCS**: Update demo.
- - **DOCS**: Add demo page.
+- **FIX**: Fix responsive layout.
+- **DOCS**: Update docs link.
+- **DOCS**: Update docs.
+- **DOCS**: Update demo.
+- **DOCS**: Add demo page.
 
 ## 0.5.0-dev.0
 
 > Note: This release has breaking changes.
 
- - **BREAKING** **FEAT**: Add plugins.
+- **BREAKING** **FEAT**: Add plugins.
 
 ## 0.4.1+2
 
- - **FIX**: Fix knobs reload for CustomStorybook.
+- **FIX**: Fix knobs reload for CustomStorybook.
 
 ## 0.4.1+1
 
- - **STYLE**: Fix formatting.
- - **DOCS**: Update README.md.
+- **STYLE**: Fix formatting.
+- **DOCS**: Update README.md.
 
 ## 0.4.1
 
- - **FEAT**: Add storybook_device_preview.
- - **CHORE**: Update dependencies.
- - **CHORE**: Restructure.
+- **FEAT**: Add storybook_device_preview.
+- **CHORE**: Update dependencies.
+- **CHORE**: Restructure.
 
 ## 0.4.0
 
- - Bump "storybook_flutter" to `0.4.0`.
+- Bump "storybook_flutter" to `0.4.0`.
 
 ## 0.3.0
 
 > Note: This release has breaking changes.
 
- - **CI**: Add CI job (#20).
- - **BREAKING** **FEAT**: Major theme upgrade.
+- **CI**: Add CI job (#20).
+- **BREAKING** **FEAT**: Major theme upgrade.
 
 ## 0.2.1
 

--- a/packages/storybook_flutter/CHANGELOG.md
+++ b/packages/storybook_flutter/CHANGELOG.md
@@ -1,12 +1,3 @@
-## 0.9.0-dev.2
-
-> Note: This release has breaking changes.
-
-- **FEAT**: Add description field to stories and all knobs.
-- **CHORE**: Add docs to all knobs.
-- **FIX**: Fix bug where desktop users could not enter space in text knob fields.
-- **CHORE**: Version bump.
-
 ## 0.9.0-dev.1
 
 - **FEAT**: Update plugins.

--- a/packages/storybook_flutter/lib/src/knobs/bool_knob.dart
+++ b/packages/storybook_flutter/lib/src/knobs/bool_knob.dart
@@ -4,24 +4,57 @@ import 'package:provider/provider.dart';
 import '../plugins/knobs.dart';
 import 'knobs.dart';
 
+/// {@template bool_knob}
+/// A knob that allows the user to toggle a boolean value.
+///
+/// See also:
+/// * [BooleanKnobWidget], which is the widget that displays the knob.
+/// {@endtemplate}
 class BoolKnob extends Knob<bool> {
-  // ignore: avoid_positional_boolean_parameters
-  BoolKnob(String label, bool value) : super(label, value);
+  /// {@macro bool_knob}
+  BoolKnob({
+    required String label,
+    String? description,
+    required bool value,
+  }) : super(
+          label: label,
+          description: description,
+          value: value,
+        );
 
   @override
-  Widget build() => BooleanKnobWidget(label: label, value: value);
+  Widget build() => BooleanKnobWidget(
+        label: label,
+        description: description,
+        value: value,
+      );
 }
 
+/// {@template boolean_knob_widget}
+/// A knob widget that allows the user to toggle a boolean value.
+///
+/// The knob is displayed as a checkbox.
+///
+/// See also:
+/// * [BoolKnob], which is the knob that this widget represents.
+/// {@endtemplate}
 class BooleanKnobWidget extends StatelessWidget {
-  const BooleanKnobWidget({Key? key, required this.label, required this.value})
-      : super(key: key);
+  /// {@macro boolean_knob_widget}
+  const BooleanKnobWidget({
+    Key? key,
+    required this.label,
+    required this.description,
+    required this.value,
+  }) : super(key: key);
 
   final String label;
+  final String? description;
   final bool value;
 
   @override
   Widget build(BuildContext context) => CheckboxListTile(
         title: Text(label),
+        subtitle: description == null ? null : Text(description!),
         value: value,
         onChanged: (v) => context.read<KnobsNotifier>().update(label, v),
       );

--- a/packages/storybook_flutter/lib/src/knobs/knobs.dart
+++ b/packages/storybook_flutter/lib/src/knobs/knobs.dart
@@ -2,15 +2,38 @@ import 'package:flutter/widgets.dart';
 
 import 'select_knob.dart';
 
+/// {@template knob}
+/// An abstract class that represents a control knob.
+///
+/// Consumers can extend this class to create custom knob types.
+/// {@endtemplate}
 abstract class Knob<T> {
-  Knob(this.label, this.value);
+  /// {@macro knob}
+  Knob({
+    required this.label,
+    this.description,
+    required this.value,
+  });
 
+  /// The label of the knob.
   final String label;
+
+  /// An optional description of the knob.
+  final String? description;
+
+  /// The current value of the knob.
+  ///
+  /// This may change as the user interacts with the knob.
   T value;
 
+  /// The build method for the knob.
+  ///
+  /// This method is responsible for building the widget that represents the
+  /// knob.
   Widget build();
 }
 
+/// {@template knobs_builder}
 /// Provides helper methods for creating knobs: control elements
 /// that can be used in stories to dynamically update its properties.
 ///
@@ -25,16 +48,29 @@ abstract class Knob<T> {
 ///    ),
 ///  )
 ///  ```
+/// {@endtemplate}
 abstract class KnobsBuilder {
-  /// Creates checkbox with [label] and [initial] value.
-  bool boolean({required String label, bool initial = false});
+  /// {@macro knobs_builder}
+  const KnobsBuilder();
 
-  /// Creates text input field with [label] and [initial] value.
-  String text({required String label, String initial = ''});
+  /// Creates checkbox with [label], [description] and [initial] value.
+  bool boolean({
+    required String label,
+    String? description,
+    bool initial = false,
+  });
+
+  /// Creates text input field with [label], [description] and [initial] value.
+  String text({
+    required String label,
+    String? description,
+    String initial = '',
+  });
 
   /// Creates slider knob with `double` value.
   double slider({
     required String label,
+    String? description,
     double initial = 0,
     double max = 1,
     double min = 0,
@@ -43,15 +79,18 @@ abstract class KnobsBuilder {
   /// Creates slider knob with `int` value.
   int sliderInt({
     required String label,
+    String? description,
     int initial = 0,
     int max = 100,
     int min = 0,
     int divisions = 100,
   });
 
-  /// Creates select field with [label], [initial] value and list of [options].
+  /// Creates select field with [label], [description], [initial] value and
+  /// list of [options].
   T options<T>({
     required String label,
+    String? description,
     required T initial,
     List<Option<T>> options = const [],
   });

--- a/packages/storybook_flutter/lib/src/knobs/select_knob.dart
+++ b/packages/storybook_flutter/lib/src/knobs/select_knob.dart
@@ -106,57 +106,56 @@ class SelectKnobWidget<T> extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) => ListTile(
-        isThreeLine: description != null,
-        title: DropdownButtonFormField<Option<T>>(
-          decoration: InputDecoration(
-            isDense: true,
-            labelText: label,
-            border: const OutlineInputBorder(),
-          ),
-          isExpanded: true,
-          value: values.firstWhereOrNull((e) => e.value == value),
-          items: [
-            for (final option in values)
-              DropdownMenuItem<Option<T>>(
-                value: option,
-                child: Builder(
-                  builder: (context) {
-                    final textTheme = Theme.of(context).textTheme;
-                    final isInDropdownRoute = _isInDropdownRoute(context);
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
 
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(option.label),
-                        if (option.description != null &&
-                            isInDropdownRoute) ...[
-                          const SizedBox(height: 4),
-                          Text(
-                            option.description!,
-                            style: textTheme.bodyText2?.copyWith(
-                              color: textTheme.caption?.color,
-                            ),
-                          ),
-                        ],
-                      ],
-                    );
-                  },
-                ),
-              ),
-          ],
-          onChanged: (v) {
-            if (v != null) {
-              context.read<KnobsNotifier>().update<T>(label, v.value);
-            }
-          },
+    return ListTile(
+      isThreeLine: description != null,
+      title: DropdownButtonFormField<Option<T>>(
+        decoration: InputDecoration(
+          isDense: true,
+          labelText: label,
+          border: const OutlineInputBorder(),
         ),
-        subtitle: description == null
-            ? null
-            : Padding(
-                padding: const EdgeInsets.only(top: 2),
-                child: Text(description!),
+        isExpanded: true,
+        value: values.firstWhereOrNull((e) => e.value == value),
+        selectedItemBuilder: (context) => [
+          for (final option in values) Text(option.label),
+        ],
+        items: [
+          for (final option in values)
+            DropdownMenuItem<Option<T>>(
+              value: option,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(option.label),
+                  if (option.description != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      option.description!,
+                      style: textTheme.bodyText2?.copyWith(
+                        color: textTheme.caption?.color,
+                      ),
+                    ),
+                  ],
+                ],
               ),
-      );
+            ),
+        ],
+        onChanged: (v) {
+          if (v != null) {
+            context.read<KnobsNotifier>().update<T>(label, v.value);
+          }
+        },
+      ),
+      subtitle: description == null
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(description!),
+            ),
+    );
+  }
 }

--- a/packages/storybook_flutter/lib/src/knobs/select_knob.dart
+++ b/packages/storybook_flutter/lib/src/knobs/select_knob.dart
@@ -5,41 +5,109 @@ import 'package:provider/provider.dart';
 import '../plugins/knobs.dart';
 import 'knobs.dart';
 
+/// {@template select_knob}
+/// A knob that allows the user to select an option from a list of options.
+///
+/// See also:
+/// * [Option], which represents a single option in the list.
+/// * [SelectKnobWidget], which is the widget that displays the knob.
+/// {@endtemplate}
 class SelectKnob<T> extends Knob<T> {
-  SelectKnob(String label, T value, this.options) : super(label, value);
+  /// {@macro select_knob}
+  SelectKnob({
+    required String label,
+    String? description,
+    required T value,
+    required this.options,
+  }) : super(
+          label: label,
+          description: description,
+          value: value,
+        );
 
+  /// The list of options that the user can select from.
+  ///
+  /// See also:
+  /// * [Option], which represents a single option in the list.
   final List<Option<T>> options;
 
   @override
   Widget build() => SelectKnobWidget<T>(
         label: label,
+        description: description,
         value: value,
         values: options,
       );
 }
 
-/// Option for select knob.
+/// {@template option}
+/// Represents a single option for a [SelectKnob].
+///
+/// Every option will be displayed in a dropdown menu.
+/// {@endtemplate}
 class Option<T> {
-  const Option(this.text, this.value);
+  /// {@macro option}
+  const Option({
+    required this.label,
+    this.description,
+    required this.value,
+  });
 
-  final String text;
+  /// The label that will be displayed in the dropdown menu.
+  final String label;
+
+  /// An optional description that will be displayed in the dropdown menu.
+  final String? description;
+
+  /// The value that will be returned when the user selects this option.
   final T value;
 }
 
+/// {@template select_knob_widget}
+/// A knob widget that allows the user to select a value from a list of options.
+///
+/// The knob is displayed as a dropdown menu.
+///
+/// See also:
+/// * [SelectKnob], which is the knob that this widget represents.
+/// {@endtemplate}
 class SelectKnobWidget<T> extends StatelessWidget {
+  /// {@macro select_knob_widget}
   const SelectKnobWidget({
     Key? key,
     required this.label,
+    required this.description,
     required this.values,
     required this.value,
   }) : super(key: key);
 
   final String label;
+  final String? description;
   final List<Option<T>> values;
   final T value;
 
+  /// Determines if the given [context] is enclosed by a dropdown menu route.
+  ///
+  /// This is used in the dropdown options builder to determine whether a
+  /// description should be shown.
+  ///
+  /// The algorithm used is quite hacky, and we should probably find a better
+  /// way to do this.
+  bool _isInDropdownRoute(BuildContext context) {
+    late final bool result;
+    try {
+      final route = ModalRoute.of(context);
+      result = route is PopupRoute && (route as dynamic).items != null;
+      // ignore: avoid_catching_errors
+    } on NoSuchMethodError {
+      result = false;
+    }
+    return result;
+  }
+
   @override
   Widget build(BuildContext context) => ListTile(
+        isThreeLine: description != null,
         title: DropdownButtonFormField<Option<T>>(
           decoration: InputDecoration(
             isDense: true,
@@ -48,17 +116,47 @@ class SelectKnobWidget<T> extends StatelessWidget {
           ),
           isExpanded: true,
           value: values.firstWhereOrNull((e) => e.value == value),
-          items: values
-              .map((e) => DropdownMenuItem<Option<T>>(
-                    value: e,
-                    child: Text(e.text),
-                  ))
-              .toList(),
+          items: [
+            for (final option in values)
+              DropdownMenuItem<Option<T>>(
+                value: option,
+                child: Builder(
+                  builder: (context) {
+                    final textTheme = Theme.of(context).textTheme;
+                    final isInDropdownRoute = _isInDropdownRoute(context);
+
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(option.label),
+                        if (option.description != null &&
+                            isInDropdownRoute) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            option.description!,
+                            style: textTheme.bodyText2?.copyWith(
+                              color: textTheme.caption?.color,
+                            ),
+                          ),
+                        ],
+                      ],
+                    );
+                  },
+                ),
+              ),
+          ],
           onChanged: (v) {
             if (v != null) {
               context.read<KnobsNotifier>().update<T>(label, v.value);
             }
           },
         ),
+        subtitle: description == null
+            ? null
+            : Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(description!),
+              ),
       );
 }

--- a/packages/storybook_flutter/lib/src/knobs/select_knob.dart
+++ b/packages/storybook_flutter/lib/src/knobs/select_knob.dart
@@ -86,25 +86,6 @@ class SelectKnobWidget<T> extends StatelessWidget {
   final List<Option<T>> values;
   final T value;
 
-  /// Determines if the given [context] is enclosed by a dropdown menu route.
-  ///
-  /// This is used in the dropdown options builder to determine whether a
-  /// description should be shown.
-  ///
-  /// The algorithm used is quite hacky, and we should probably find a better
-  /// way to do this.
-  bool _isInDropdownRoute(BuildContext context) {
-    late final bool result;
-    try {
-      final route = ModalRoute.of(context);
-      result = route is PopupRoute && (route as dynamic).items != null;
-      // ignore: avoid_catching_errors
-    } on NoSuchMethodError {
-      result = false;
-    }
-    return result;
-  }
-
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;

--- a/packages/storybook_flutter/lib/src/knobs/slider_knob.dart
+++ b/packages/storybook_flutter/lib/src/knobs/slider_knob.dart
@@ -4,25 +4,50 @@ import 'package:provider/provider.dart';
 import '../plugins/knobs.dart';
 import 'knobs.dart';
 
-typedef FormatDouble = String Function(double value);
+/// A type definition for a function that formats a [double] value.
+typedef DoubleFormatter = String Function(double value);
 
+/// {@template slider_knob}
+/// A knob that allows the user to select a value from a range.
+///
+/// See also:
+/// * [SliderKnobWidget], which is the widget that displays the knob.
+/// {@endtemplate}
 class SliderKnob extends Knob<double> {
-  SliderKnob(
-    String label, {
+  /// {@macro slider_knob}
+  SliderKnob({
+    required String label,
+    String? description,
     required double value,
     required this.max,
     required this.min,
     this.divisions,
     this.formatValue = _defaultFormat,
-  }) : super(label, value);
+  }) : super(
+          label: label,
+          description: description,
+          value: value,
+        );
+
+  /// The maximum value of the slider.
   final double max;
+
+  /// The minimum value of the slider.
   final double min;
+
+  /// The number of divisions in the slider.
   final int? divisions;
-  final FormatDouble formatValue;
+
+  /// An optional function that formats the value of the slider.
+  ///
+  /// By default, the value is formatted as a decimal number with two digits
+  /// after the decimal point.
+  final DoubleFormatter formatValue;
 
   @override
   Widget build() => SliderKnobWidget(
         label: label,
+        description: description,
         value: value,
         min: min,
         max: max,
@@ -31,10 +56,20 @@ class SliderKnob extends Knob<double> {
       );
 }
 
+/// {@template slider_knob_widget}
+/// A knob widget that allows the user to select a value from a range.
+///
+/// The knob is displayed as a [Slider].
+///
+/// See also:
+/// * [SliderKnob], which is the knob that this widget represents.
+/// {@endtemplate}
 class SliderKnobWidget extends StatelessWidget {
+  /// {@macro slider_knob_widget}
   const SliderKnobWidget({
     Key? key,
     required this.label,
+    required this.description,
     required this.value,
     required this.min,
     required this.max,
@@ -43,23 +78,43 @@ class SliderKnobWidget extends StatelessWidget {
   }) : super(key: key);
 
   final String label;
+  final String? description;
   final double min;
   final double max;
   final double value;
   final int? divisions;
-  final FormatDouble formatValue;
+  final DoubleFormatter formatValue;
 
   @override
-  Widget build(BuildContext context) => ListTile(
-        subtitle: Slider(
-          value: value,
-          onChanged: (v) => context.read<KnobsNotifier>().update(label, v),
-          max: max,
-          min: min,
-          divisions: divisions,
-        ),
-        title: Text('$label (${formatValue(value)})'),
-      );
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return ListTile(
+      title: Text('$label (${formatValue(value)})'),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (description != null) ...[
+            Text(
+              description!,
+              style: textTheme.bodyText2?.copyWith(
+                color: textTheme.caption?.color,
+              ),
+            ),
+            const SizedBox(height: 4),
+          ],
+          Slider(
+            value: value,
+            onChanged: (v) => context.read<KnobsNotifier>().update(label, v),
+            max: max,
+            min: min,
+            divisions: divisions,
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 String _defaultFormat(double value) => value.toStringAsFixed(2);

--- a/packages/storybook_flutter/lib/src/knobs/string_knob.dart
+++ b/packages/storybook_flutter/lib/src/knobs/string_knob.dart
@@ -4,30 +4,86 @@ import 'package:provider/provider.dart';
 import '../plugins/knobs.dart';
 import 'knobs.dart';
 
+/// {@template string_knob}
+/// A knob that allows the user to edit a string value.
+///
+/// See also:
+/// * [StringKnobWidget], which is the widget that displays the knob.
+/// {@endtemplate}
 class StringKnob extends Knob<String> {
-  StringKnob(String label, String value) : super(label, value);
+  /// {@macro string_knob}
+  StringKnob({
+    required String label,
+    String? description,
+    required String value,
+  }) : super(
+          label: label,
+          description: description,
+          value: value,
+        );
 
   @override
-  Widget build() => StringKnobWidget(label: label, value: value);
+  Widget build() => StringKnobWidget(
+        label: label,
+        description: description,
+        value: value,
+      );
 }
 
+/// {@template string_knob_widget}
+/// A knob widget that allows the user to edit a string value.
+///
+/// The knob is displayed as a [TextFormField].
+///
+/// See also:
+/// * [StringKnob], which is the knob that this widget represents.
+/// {@endtemplate}
 class StringKnobWidget extends StatelessWidget {
-  const StringKnobWidget({Key? key, required this.label, required this.value})
-      : super(key: key);
+  /// {@macro string_knob_widget}
+  const StringKnobWidget({
+    Key? key,
+    required this.label,
+    required this.description,
+    required this.value,
+  }) : super(key: key);
 
   final String label;
+  final String? description;
   final String value;
 
   @override
-  Widget build(BuildContext context) => ListTile(
-        title: TextFormField(
-          decoration: InputDecoration(
-            isDense: true,
-            labelText: label,
-            border: const OutlineInputBorder(),
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        vertical: 8,
+        horizontal: 16,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextFormField(
+            decoration: InputDecoration(
+              isDense: false,
+              labelText: label,
+              border: const OutlineInputBorder(),
+            ),
+            initialValue: value,
+            onChanged: (v) => context.read<KnobsNotifier>().update(label, v),
           ),
-          initialValue: value,
-          onChanged: (v) => context.read<KnobsNotifier>().update(label, v),
-        ),
-      );
+          if (description != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                description!,
+                style: textTheme.bodyText2?.copyWith(
+                  color: textTheme.caption?.color,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
 }

--- a/packages/storybook_flutter/lib/src/plugins/contents.dart
+++ b/packages/storybook_flutter/lib/src/plugins/contents.dart
@@ -86,12 +86,13 @@ class _ContentsState extends State<_Contents> {
   }
 
   Widget _buildStoryTile(Story story) => ListTile(
+        selected: story == context.watch<StoryNotifier>().value,
         title: Text(story.name),
+        subtitle: story.description == null ? null : Text(story.description!),
         onTap: () {
           final onStorySelected = widget.onStorySelected;
           onStorySelected(story);
         },
-        selected: story == context.watch<StoryNotifier>().value,
       );
 
   Widget _buildSection(String title, Iterable<Story> stories) => ExpansionTile(

--- a/packages/storybook_flutter/lib/src/plugins/knobs.dart
+++ b/packages/storybook_flutter/lib/src/plugins/knobs.dart
@@ -98,33 +98,6 @@ class KnobsNotifier extends ChangeNotifier implements KnobsBuilder {
 
   void _onStoryChanged() => notifyListeners();
 
-  @override
-  bool boolean({required String label, bool initial = false}) =>
-      _addKnob(BoolKnob(label, initial));
-
-  @override
-  String text({required String label, String initial = ''}) =>
-      _addKnob(StringKnob(label, initial));
-
-  @override
-  T options<T>({
-    required String label,
-    required T initial,
-    List<Option<T>> options = const [],
-  }) =>
-      _addKnob(SelectKnob(label, initial, options));
-
-  T _addKnob<T>(Knob<T> value) {
-    final story = _storyNotifier.value!;
-    final knobs = _knobs.putIfAbsent(story.name, () => <String, Knob>{});
-
-    return (knobs.putIfAbsent(value.label, () {
-      Future.microtask(notifyListeners);
-      return value;
-    }) as Knob<T>)
-        .value;
-  }
-
   void update<T>(String label, T value) {
     final story = _storyNotifier.value;
     if (story == null) return;
@@ -146,31 +119,99 @@ class KnobsNotifier extends ChangeNotifier implements KnobsBuilder {
     return _knobs[story.name]?.values.toList() ?? [];
   }
 
+  T _addKnob<T>(Knob<T> value) {
+    final story = _storyNotifier.value!;
+    final knobs = _knobs.putIfAbsent(story.name, () => <String, Knob>{});
+
+    return (knobs.putIfAbsent(value.label, () {
+      Future.microtask(notifyListeners);
+      return value;
+    }) as Knob<T>)
+        .value;
+  }
+
+  @override
+  bool boolean({
+    required String label,
+    String? description,
+    bool initial = false,
+  }) =>
+      _addKnob(
+        BoolKnob(
+          label: label,
+          description: description,
+          value: initial,
+        ),
+      );
+
+  @override
+  String text({
+    required String label,
+    String? description,
+    String initial = '',
+  }) =>
+      _addKnob(
+        StringKnob(
+          label: label,
+          description: description,
+          value: initial,
+        ),
+      );
+
+  @override
+  T options<T>({
+    required String label,
+    String? description,
+    required T initial,
+    List<Option<T>> options = const [],
+  }) =>
+      _addKnob(
+        SelectKnob(
+          label: label,
+          description: description,
+          value: initial,
+          options: options,
+        ),
+      );
+
   @override
   double slider({
     required String label,
+    String? description,
     double initial = 0,
     double max = 1,
     double min = 0,
   }) =>
-      _addKnob(SliderKnob(label, value: initial, max: max, min: min));
+      _addKnob(
+        SliderKnob(
+          label: label,
+          description: description,
+          value: initial,
+          max: max,
+          min: min,
+        ),
+      );
 
   @override
   int sliderInt({
     required String label,
+    String? description,
     int initial = 0,
     int max = 100,
     int min = 0,
     int divisions = 100,
   }) =>
-      _addKnob(SliderKnob(
-        label,
-        value: initial.toDouble(),
-        max: max.toDouble(),
-        min: min.toDouble(),
-        divisions: divisions,
-        formatValue: (v) => v.toInt().toString(),
-      )).toInt();
+      _addKnob(
+        SliderKnob(
+          label: label,
+          description: description,
+          value: initial.toDouble(),
+          max: max.toDouble(),
+          min: min.toDouble(),
+          divisions: divisions,
+          formatValue: (v) => v.toInt().toString(),
+        ),
+      ).toInt();
 
   @override
   void dispose() {

--- a/packages/storybook_flutter/lib/src/story.dart
+++ b/packages/storybook_flutter/lib/src/story.dart
@@ -3,11 +3,13 @@ import 'package:flutter/widgets.dart';
 class Story {
   Story({
     required this.name,
+    this.description,
     this.section = '',
     required this.builder,
   });
 
   final String name;
+  final String? description;
   final String section;
   final WidgetBuilder builder;
 }

--- a/packages/storybook_flutter/pubspec.yaml
+++ b/packages/storybook_flutter/pubspec.yaml
@@ -1,19 +1,20 @@
 name: storybook_flutter
-description: A storybook for Flutter widgets. Live preview of isolated widgets for faster development and showcase.
-version: 0.9.0-dev.1
+description: A storybook for Flutter widgets. Live preview of isolated widgets
+  for faster development and showcase.
+version: 0.9.0-dev.2
 homepage: https://github.com/ookami-kb/storybook_flutter
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   collection: ^1.15.0
   device_frame: ^1.0.0
   flutter:
     sdk: flutter
-  freezed_annotation: '>=0.14.0 <2.0.0'
+  freezed_annotation: ">=0.14.0 <2.0.0"
   nested: ^1.0.0
-  provider: '>=6.0.0 <7.0.0'
+  provider: ">=6.0.0 <7.0.0"
   recase: ^4.0.0
 
 dev_dependencies:

--- a/packages/storybook_flutter/pubspec.yaml
+++ b/packages/storybook_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: storybook_flutter
 description: A storybook for Flutter widgets. Live preview of isolated widgets
   for faster development and showcase.
-version: 0.9.0-dev.2
+version: 0.9.0-dev.1
 homepage: https://github.com/ookami-kb/storybook_flutter
 
 environment:


### PR DESCRIPTION
## Description

> This is a replacement PR for #60 that targets the `next` branch.

This PR adds an optional `description` field to the `Story` class all available knobs, along with the logic to display these descriptions (if provided).

A list of all the changes can be found below.
If you have any questions or want additional information, feel free to reach out. Great library, by the way! 😄 

| Story descriptions | Knob descriptions |
| --- | --- |
|![stylebook_pr_changes_1](https://user-images.githubusercontent.com/14292245/146200217-aaa73b8f-8c48-4b12-9c2e-4691eb52599a.jpg)|![stylebook_pr_changes_2](https://user-images.githubusercontent.com/14292245/146200258-182458c9-5b8d-4c33-8354-5f532fb17a01.jpg)|

### Summary of changes

- **FEAT**: Add description field to stories and all knobs.
- **CHORE**: Add docs to all knobs.
- **FIX**: Fix bug where desktop users could not enter space in text knob fields.
- **CHORE**: Version bump.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
