### PR TITLE
feat: screenshot feature

### DIFF
--- a/packages/storybook_flutter/lib/src/control_panel/widgets/control_panel.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/control_panel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:storybook_flutter/src/control_panel/provider.dart';
 import 'package:storybook_flutter/src/control_panel/widgets/full_screen_button.dart';
+import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/screenshot_button.dart';
 import 'package:storybook_flutter/src/plugins/plugin.dart';
 import 'package:storybook_flutter/src/plugins/plugin_settings_notifier.dart';
 import 'package:storybook_flutter/src/story_provider.dart';
@@ -98,6 +99,12 @@ class ControlPanel extends StatelessWidget {
                         .map(buildIcon)
                         .toList(),
                     const Spacer(),
+                    Consumer<StoryProvider>(
+                        builder: (_, provider, __) => Visibility(
+                              visible: provider.currentStory != null,
+                              replacement: const SizedBox(),
+                              child: const ScreenShotButton(),
+                            )),
                     const FullScreenButton(),
                     const ThemeSwitcher(),
                   ],

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart
@@ -1,0 +1,12 @@
+import './screenshot_handler_unsupported.dart';
+import '../screenshot_entity.dart';
+
+abstract class ScreenShotHandlerInterface {
+  Future<void> saveImage(ScreenShot screenShot);
+}
+
+class ScreenShotHandler implements ScreenShotHandlerInterface {
+  @override
+  Future<void> saveImage(ScreenShot screenShot) =>
+      ScreenShotHandlerImpl().saveImage(screenShot);
+}

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart
@@ -1,5 +1,7 @@
 import './screenshot_handler_unsupported.dart'
-    if (dart.library.html) './screenshot_handler_web.dart';
+    if (dart.library.html) './screenshot_handler_web.dart'
+    if (dart.library.io) './screenshot_handler_io.dart';
+
 import '../screenshot_entity.dart';
 
 abstract class ScreenShotHandlerInterface {

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart
@@ -1,4 +1,5 @@
-import './screenshot_handler_unsupported.dart';
+import './screenshot_handler_unsupported.dart'
+    if (dart.library.html) './screenshot_handler_web.dart';
 import '../screenshot_entity.dart';
 
 abstract class ScreenShotHandlerInterface {

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler_io.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler_io.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart';
+import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/screenshot_entity.dart';
+
+class ScreenShotHandlerImpl implements ScreenShotHandlerInterface {
+  @override
+  Future<void> saveImage(ScreenShot screenShot) async {
+    final file = await File(
+            '${await _directoryPath}/screenshots/${screenShot.filename}.png')
+        .create(recursive: true);
+    await file.writeAsBytes(screenShot.image);
+  }
+
+  Future<String> get _directoryPath async {
+    if (Platform.isAndroid) {
+      return (await getExternalStorageDirectory())!.path;
+    }
+    return (await getApplicationDocumentsDirectory()).path;
+  }
+}

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler_unsupported.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler_unsupported.dart
@@ -1,0 +1,10 @@
+import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart';
+
+import '../screenshot_entity.dart';
+
+class ScreenShotHandlerImpl implements ScreenShotHandlerInterface {
+  @override
+  Future<void> saveImage(ScreenShot screenShot) async {
+    throw UnimplementedError();
+  }
+}

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler_web.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/handler/screenshot_handler_web.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:html' as html;
+
 import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/handler/screenshot_handler.dart';
 import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/screenshot_entity.dart';
 
@@ -5,6 +8,10 @@ import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/sc
 class ScreenShotHandlerImpl implements ScreenShotHandlerInterface {
   @override
   Future<void> saveImage(ScreenShot screenShot) async {
-    throw UnimplementedError();
+    final base64data = base64Encode(screenShot.image);
+    html.AnchorElement(href: 'data:image/jpeg;base64,$base64data')
+      ..download = '${screenShot.filename}.png'
+      ..click()
+      ..remove();
   }
 }

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_button.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_button.dart
@@ -1,20 +1,35 @@
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
+import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/screenshot_entity.dart';
 import 'package:storybook_flutter/src/story_provider.dart';
 
 class ScreenShotButton extends StatelessWidget {
   const ScreenShotButton({Key? key}) : super(key: key);
 
   Future<void> _print(BuildContext context) async {
-    final story = context.read<StoryProvider>().currentStory;
-    if (story == null) return;
-    print('Should capture Story as Image and save it');
+    final image = await _captureStoryAsImage(context);
+    if (image == null) return;
+    print('Should save ${image.filename} in local storage');
   }
 
+  Future<ScreenShot?> _captureStoryAsImage(BuildContext context) async {
+    final story = context.read<StoryProvider>().currentStory;
+    if (story == null) return null;
+
+    final boundary = story.screenShotKey.currentContext!.findRenderObject()
+        as RenderRepaintBoundary;
+    final image = await boundary.toImage(
+        pixelRatio: MediaQuery.of(context).devicePixelRatio);
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    if (byteData == null) return null;
+    return ScreenShot(byteData.buffer.asUint8List(), story.name);
+  }
 
   @override
   Widget build(BuildContext context) => IconButton(
-    onPressed: () => _print(context),
-    icon: const Icon(Icons.fit_screen_outlined),
-  );
+        onPressed: () => _print(context),
+        icon: const Icon(Icons.fit_screen_outlined),
+      );
 }

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_button.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_button.dart
@@ -5,13 +5,15 @@ import 'package:provider/provider.dart';
 import 'package:storybook_flutter/src/control_panel/widgets/screenshot_button/screenshot_entity.dart';
 import 'package:storybook_flutter/src/story_provider.dart';
 
+import 'handler/screenshot_handler.dart';
+
 class ScreenShotButton extends StatelessWidget {
   const ScreenShotButton({Key? key}) : super(key: key);
 
   Future<void> _print(BuildContext context) async {
     final image = await _captureStoryAsImage(context);
     if (image == null) return;
-    print('Should save ${image.filename} in local storage');
+    return ScreenShotHandler().saveImage(image);
   }
 
   Future<ScreenShot?> _captureStoryAsImage(BuildContext context) async {

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_button.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_button.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:storybook_flutter/src/story_provider.dart';
+
+class ScreenShotButton extends StatelessWidget {
+  const ScreenShotButton({Key? key}) : super(key: key);
+
+  Future<void> _print(BuildContext context) async {
+    final story = context.read<StoryProvider>().currentStory;
+    if (story == null) return;
+    print('Should capture Story as Image and save it');
+  }
+
+
+  @override
+  Widget build(BuildContext context) => IconButton(
+    onPressed: () => _print(context),
+    icon: const Icon(Icons.fit_screen_outlined),
+  );
+}

--- a/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_entity.dart
+++ b/packages/storybook_flutter/lib/src/control_panel/widgets/screenshot_button/screenshot_entity.dart
@@ -1,0 +1,8 @@
+import 'dart:typed_data';
+
+class ScreenShot {
+  const ScreenShot(this.image, this.filename);
+
+  final Uint8List image;
+  final String filename;
+}

--- a/packages/storybook_flutter/lib/src/story.dart
+++ b/packages/storybook_flutter/lib/src/story.dart
@@ -12,7 +12,7 @@ import 'package:storybook_flutter/src/storybook.dart';
 ///
 /// It's better to use it to demonstrate a single widget (e.g. Button).
 class Story extends StatefulWidget {
-  const Story({
+  Story({
     Key? key,
     required this.name,
     required StoryBuilder builder,
@@ -68,6 +68,9 @@ class Story extends StatefulWidget {
   /// Padding of the story.
   final EdgeInsets padding;
 
+  /// key to provide a context to find a render object to export as image
+  final GlobalKey screenShotKey = GlobalKey();
+
   String get path => ReCase(name).paramCase;
 
   @override
@@ -99,7 +102,7 @@ class _StoryState extends State<Story> {
       );
     }
 
-    return child;
+    return RepaintBoundary(key: widget.screenShotKey, child: child);
   }
 }
 

--- a/packages/storybook_flutter/pubspec.yaml
+++ b/packages/storybook_flutter/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   freezed_annotation: ^0.15.0
+  path_provider: ^2.0.8
   provider: '>=5.0.0 <7.0.0'
   recase: ^4.0.0
 


### PR DESCRIPTION
Feature requested: https://github.com/ookami-kb/storybook_flutter/issues/50

## Implemented screenshot feature to Web and Mobile
- add a button on the control panel 
- download story as an image on Web
- save the story as an image on the application folder on Mobile.

### Future improvements suggestions:
- Add unit and widget tests
- On mobile, save screenshots in the gallery
- Add a crop feature

## Result
> Button added
![image](https://user-images.githubusercontent.com/87378048/147890749-85ed98ed-fb85-44a3-ad2b-bee44456e3c6.png)

> Screenshot with device preview
![Input field (2)](https://user-images.githubusercontent.com/87378048/147890763-580f2275-c15e-44fb-a5ac-e4be5c7c40ad.png)

> Simple screenshot
![Input field](https://user-images.githubusercontent.com/87378048/147890770-083711a1-aee9-45d7-a984-d47a782c5c66.png)

