### PR TITLE
feat: Add addKnob method to KnobsBuilder

### DIFF
--- a/packages/storybook_flutter/lib/src/knobs/knobs_builder.dart
+++ b/packages/storybook_flutter/lib/src/knobs/knobs_builder.dart
@@ -1,4 +1,4 @@
-import 'package:storybook_flutter/src/knobs/select_knob.dart';
+import 'package:storybook_flutter/src/knobs/knobs.dart';
 
 /// {@template knobs_builder}
 /// Provides helper methods for creating knobs: control elements
@@ -68,6 +68,10 @@ abstract class KnobsBuilder {
     required T initial,
     List<Option<T>> options = const [],
   });
+
+  /// Allows to add a custom knob.
+  /// Using the convenience functions (boolean, text, ...) is recommended.
+  T addKnob<T>(Knob<T> knob);
 }
 
 /// {@template nullable_knobs_builder}

--- a/packages/storybook_flutter/lib/src/plugins/knobs.dart
+++ b/packages/storybook_flutter/lib/src/plugins/knobs.dart
@@ -126,6 +126,7 @@ class KnobsNotifier extends ChangeNotifier implements KnobsBuilder {
 
   /// Allows to add a knob to the current story.
   /// Using the convenience functions (boolean, text, ...) is recommended.
+  @override
   T addKnob<T>(Knob<T> value) {
     // ignore: avoid-non-null-assertion, having null here is a bug
     final story = _storyNotifier.currentStory!;


### PR DESCRIPTION
This was missed in my "opening" of the addKnob method.
Since the KnobsBuilder does not have the method definition
one cannot add custom knobs via custom extension.
This adds the method definition to the builder such
that custom knobs can be added in the future.