### PR TITLE
fix: add missing Cupertino localisations

### DIFF
--- a/packages/storybook_flutter/lib/src/plugins/knobs.dart
+++ b/packages/storybook_flutter/lib/src/plugins/knobs.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart' show DefaultCupertinoLocalizations;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:storybook_flutter/src/knobs/knobs.dart';
@@ -66,6 +67,7 @@ Widget _buildWrapper(BuildContext context, Widget? child) =>
                             delegates: const [
                               DefaultMaterialLocalizations.delegate,
                               DefaultWidgetsLocalizations.delegate,
+                              DefaultCupertinoLocalizations.delegate,
                             ],
                             locale: const Locale('en', 'US'),
                             child: Navigator(

--- a/packages/storybook_flutter/lib/src/plugins/plugin_panel.dart
+++ b/packages/storybook_flutter/lib/src/plugins/plugin_panel.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart' show DefaultCupertinoLocalizations;
 import 'package:flutter/material.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:provider/provider.dart';
@@ -48,6 +49,7 @@ class _PluginPanelState extends State<PluginPanel> {
                 delegates: const [
                   DefaultMaterialLocalizations.delegate,
                   DefaultWidgetsLocalizations.delegate,
+                  DefaultCupertinoLocalizations.delegate,
                 ],
                 locale: const Locale('en', 'US'),
                 child: Dialog(


### PR DESCRIPTION
Even though the Knobs are based on Material Design, the Flutter SDK still instantiates Cupertino based widgets for example for the `TextField` widget, since it will display a `CupertinoTextSelectionToolbarButton`. This will lead to an Exception on iOS platforms when that toolbar needs to be rendered.

This PR fixes this exception by also providing the `DefaultCupertinoLocalizations` delegate.